### PR TITLE
make instrument name part of config

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -1,12 +1,15 @@
 # The streaming control board's IP address
 board_ip = "192.168.1.250"
 
+# The instrument name
+instrument_name = "TESTMACHINE"
+
 # PV prefix of all PVs in this IOC
-pv_prefix = "IN:EMMA-B:"
+pv_prefix = "TE:TESTMACHINE:KDAECTRL:"
 
 # Kafka topic on which to produce runInfo messages
 # (usually <instrument>_runInfo)
-runinfo_topic = "EMMA-B_runInfo"
+runinfo_topic = "TESTMACHINE_runInfo"
 
 # Local IP to send to the streaming board so it responds thereafter
 local_ip = "192.168.1.17"

--- a/src/kafka_dae_control/config.py
+++ b/src/kafka_dae_control/config.py
@@ -1,7 +1,6 @@
 """Utilities for reading Control IOC configuration from TOML."""
 
 import ipaddress
-import socket
 import tomllib
 from pathlib import Path
 
@@ -19,7 +18,10 @@ class ControlConfig(BaseModel):
     pv_prefix: str
     """PV prefix of all PVs in this IOC"""
 
-    runinfo_topic: str = f"{socket.gethostname()}_runInfo"
+    instrument_name: str
+    """Name of the instrument"""
+
+    runinfo_topic: str
     """Run info topic to push run starts/stops to"""
 
     local_ip: ipaddress.IPv4Address

--- a/src/kafka_dae_control/data.py
+++ b/src/kafka_dae_control/data.py
@@ -1,7 +1,6 @@
 """Data class containing the state of the program."""
 
 import logging
-import socket
 from typing import TypeVar
 
 from pydantic import BaseModel, Field
@@ -36,6 +35,3 @@ class Data(BaseModel):
     blocks: list[str] = Field(default_factory=list)
     """List of blocks to be inserted in the run start nexus structure.
      These are prefixed with the instrument and block server prefixes"""
-
-    instrument_name: str = Field(default_factory=socket.gethostname)
-    """The name of the instrument"""

--- a/src/kafka_dae_control/pvs/static_pvs.py
+++ b/src/kafka_dae_control/pvs/static_pvs.py
@@ -51,9 +51,6 @@ class StaticPVs:
         self.users = SharedPV(
             nt=NTScalar("s", display=True, form=True), initial={"value": data.users}
         )
-        self.inst_name = SharedPV(
-            nt=NTScalar("s", display=True, form=True), initial={"value": data.instrument_name}
-        )
 
         @self.title.put  # pragma: no cover
         def title_put(pv: SharedPV, op: ServerOperation) -> None:

--- a/src/kafka_dae_control/run_start_nexus_structure.py
+++ b/src/kafka_dae_control/run_start_nexus_structure.py
@@ -3,14 +3,17 @@
 import json
 import typing
 
+from kafka_dae_control.config import ControlConfig
+
 if typing.TYPE_CHECKING:
     from kafka_dae_control.data import Data
 
 
-def generate_nexus_structure(data: "Data") -> str:
+def generate_nexus_structure(config: ControlConfig, data: "Data") -> str:
     """Generate the nexus structure for a run start using the data class.
 
     Args:
+        config: The program's configuration
         data: The data class containing the state of the program
 
     Returns: a JSON-formatted string containing the nexus structure
@@ -30,7 +33,7 @@ def generate_nexus_structure(data: "Data") -> str:
                                 {
                                     "type": "stream",
                                     "stream": {
-                                        "topic": f"{data.instrument_name}_events",
+                                        "topic": f"{config.instrument_name}_events",
                                         "source": "KDAECTRL",
                                         "writer_module": "ev44",
                                     },
@@ -45,7 +48,7 @@ def generate_nexus_structure(data: "Data") -> str:
                                 {
                                     "type": "stream",
                                     "stream": {
-                                        "topic": f"{data.instrument_name}_sampleEnv",
+                                        "topic": f"{config.instrument_name}_sampleEnv",
                                         "source": block,
                                         "writer_module": "f144",
                                     },

--- a/src/kafka_dae_control/worker_event_handlers.py
+++ b/src/kafka_dae_control/worker_event_handlers.py
@@ -68,11 +68,11 @@ def handle_begin(  # noqa: PLR0913, PLR0917
     data.job_id = str(uuid.uuid4())
     blob = serialise_pl72(
         job_id=data.job_id,
-        filename=f"{data.instrument_name}{data.run_number}.nxs",
+        filename=f"{config.instrument_name}{data.run_number}.nxs",
         start_time=datetime.now(ZoneInfo("Europe/London")),
         run_name=str(data.run_number),
-        nexus_structure=generate_nexus_structure(data),
-        instrument_name=data.instrument_name,
+        nexus_structure=generate_nexus_structure(config, data),
+        instrument_name=config.instrument_name,
         control_topic=config.runinfo_topic,
     )
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ def conf() -> ControlConfig:
             "192.168.1.2",
         ),
         kafka_producer={},
+        instrument_name="TEST",
+        runinfo_topic="run-info-topic",
     )
 
 

--- a/tests/test_comms.py
+++ b/tests/test_comms.py
@@ -32,6 +32,8 @@ conf = ControlConfig(
     local_ip=ipaddress.IPv4Address("127.0.0.1"),
     kafka_producer={},
     pv_update_interval_s=1.0,
+    instrument_name="TEST",
+    runinfo_topic="run-info-topic",
 )
 
 
@@ -220,6 +222,8 @@ def test_set_board_response_ip_sets_ip(mock_write_verify):  # pyright: ignore re
         pv_prefix="",
         local_ip=ipaddress.IPv4Address("192.168.1.101"),
         kafka_producer={},
+        instrument_name="TEST",
+        runinfo_topic="run-info-topic",
     )
     lock = MagicMock(spec=RLock())
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ def test_config_loading():
     m = mock_open(
         read_data=b"""
 board_ip = "192.168.1.250"
+instrument_name = "TESTMACHINE"
 pv_prefix = "TE:TESTMACHINE:KDAECTRL:"
 runinfo_topic = "somemachine_runInfo"
 # a comment
@@ -28,6 +29,7 @@ state_file = "./state1.json"
     with patch("kafka_dae_control.config.open", m):
         config = load_config("")
 
+    assert config.instrument_name == "TESTMACHINE"
     assert config.board_ip == ipaddress.IPv4Address("192.168.1.250")
     assert config.runinfo_topic == "somemachine_runInfo"
     assert config.pv_prefix == "TE:TESTMACHINE:KDAECTRL:"

--- a/tests/test_run_start_nexus_structure.py
+++ b/tests/test_run_start_nexus_structure.py
@@ -1,15 +1,16 @@
 import json
 
+from kafka_dae_control.config import ControlConfig
 from kafka_dae_control.data import Data
 from kafka_dae_control.run_start_nexus_structure import generate_nexus_structure
 
 
-def test_run_start_nexus_structure_contains_blocks_and_events():
+def test_run_start_nexus_structure_contains_blocks_and_events(conf: ControlConfig):
     d = Data(running=False)
     d.blocks = ["a", "b"]
-    d.instrument_name = "MUSHROOM"
+    conf.instrument_name = "MUSHROOM"
 
-    g = generate_nexus_structure(d)
+    g = generate_nexus_structure(conf, d)
     j = json.loads(g)
 
     assert "a" == j["children"][0]["children"][1]["children"][0]["stream"]["source"]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -31,6 +31,7 @@ def test_handshake_added_to_queue(mock_queue, mock_thread, mock_camonitor, *_): 
                 runinfo_topic="",
                 local_ip=local_ip,
                 kafka_producer={},
+                instrument_name="TEST",
             )
         )
 

--- a/tests/test_worker_event_handlers.py
+++ b/tests/test_worker_event_handlers.py
@@ -20,7 +20,7 @@ from kafka_dae_control.worker_event_handlers import (
 def test_beginning_starts_hardware_sends_run_start_and_sets_running(
     data: Data, conf: ControlConfig
 ):
-    data.instrument_name = "TESTINST"
+    conf.instrument_name = "TESTINST"
     data.run_number = 123
     producer = Mock()
     sock = Mock()


### PR DESCRIPTION
This moves instrument_name to the config file, removes the instname PV (as we are thinking of removing stuff like this anyway) and uses the same prefix convention as kdaediag. 