### PR TITLE
Resend IP after N comms errors in a row

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -26,6 +26,9 @@ local_ip = "192.168.1.17"
 # file to save state to
 state_file = "state.json"
 
+# Resend IP address to streaming control board after this many comms failures in a row
+resend_ip_after_connection_failures = 10
+
 [kafka_producer]
 "bootstrap.servers" = "livedata.isis.cclrc.ac.uk:31092"
 "enable.idempotence" = "true"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,6 +34,7 @@ nitpick_ignore_regex = [
     ("py:class", r"^confluent_kafka.cimpl.Message"),
     ("py:class", r"^kafka_dae_control.comms.VerifyFunc"),
     ("py:class", r"^pydantic.main.BaseModel"),
+    ("py:class", r"^annotated_types.Gt$"),
 ]
 
 myst_enable_extensions = ["dollarmath", "strikethrough", "colon_fence", "attrs_block"]

--- a/src/kafka_dae_control/config.py
+++ b/src/kafka_dae_control/config.py
@@ -5,7 +5,7 @@ import tomllib
 from functools import cached_property
 from pathlib import Path
 
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, PositiveInt, ValidationError
 
 from kafka_dae_control.defaults import FLUSH_TIMEOUT_S, READ_PORT, WRITE_PORT
 from kafka_dae_control.firmware_xml import parse_register_map
@@ -58,6 +58,13 @@ class ControlConfig(BaseModel):
 
     flush_timeout_s: int = FLUSH_TIMEOUT_S
     """The timeout for a flush after producing run info messages"""
+
+    resend_ip_after_connection_failures: PositiveInt = 50
+    """
+    If this many communication failures happen in a row, resend the local
+    IP address to the streaming control board. This can be required to restore
+    communication after the streaming control board is restarted.
+    """
 
     @cached_property
     def register_map(self) -> dict[str, int]:

--- a/src/kafka_dae_control/config.py
+++ b/src/kafka_dae_control/config.py
@@ -59,7 +59,7 @@ class ControlConfig(BaseModel):
     flush_timeout_s: int = FLUSH_TIMEOUT_S
     """The timeout for a flush after producing run info messages"""
 
-    resend_ip_after_connection_failures: PositiveInt = 50
+    resend_ip_after_connection_failures: PositiveInt = 10
     """
     If this many communication failures happen in a row, resend the local
     IP address to the streaming control board. This can be required to restore

--- a/src/kafka_dae_control/threads/hardware_polling_thread.py
+++ b/src/kafka_dae_control/threads/hardware_polling_thread.py
@@ -58,7 +58,7 @@ def hardware_poll_thread(
         ):
             # We've failed to communicate with the board several times in a row.
             # Maybe it has been power cycled and lost IP to respond to.
-            logger.info(
+            logger.error(
                 "Hardware polling failed %s times in a row. "
                 "Attempting to resend local IP to streaming control board to recover. "
                 "If the connection does not recover, the streaming control board may be offline.",

--- a/src/kafka_dae_control/threads/hardware_polling_thread.py
+++ b/src/kafka_dae_control/threads/hardware_polling_thread.py
@@ -15,7 +15,12 @@ from kafka_dae_control.defaults import (
     Registers,
     RunRegister,
 )
-from kafka_dae_control.worker_event_types import HardwareUpdate, HardwareUpdateEvent, WorkerEvent
+from kafka_dae_control.worker_event_types import (
+    HardwareUpdate,
+    HardwareUpdateEvent,
+    SetIPEvent,
+    WorkerEvent,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -35,14 +40,38 @@ def hardware_poll_thread(
         sock_lock: the lock to use when using the socket instance
 
     """
+    consecutive_comms_errors = 0
     while True:
-        poll_hardware(config, queue, sock, sock_lock)
+        success = poll_hardware(config, queue, sock, sock_lock)
+
+        if success:
+            consecutive_comms_errors = 0
+        else:
+            consecutive_comms_errors += 1
+            logger.debug(
+                "%s comms errors in a row while polling hardware", consecutive_comms_errors
+            )
+
+        if (
+            consecutive_comms_errors > 0
+            and consecutive_comms_errors % config.resend_ip_after_connection_failures == 0
+        ):
+            # We've failed to communicate with the board several times in a row.
+            # Maybe it has been power cycled and lost IP to respond to.
+            logger.info(
+                "Hardware polling failed %s times in a row. "
+                "Attempting to resend local IP to streaming control board to recover. "
+                "If the connection does not recover, the streaming control board may be offline.",
+                consecutive_comms_errors,
+            )
+            queue.put(SetIPEvent())
+
         sleep(config.poll_interval_s)
 
 
 def poll_hardware(
     config: ControlConfig, queue: Queue[Any], sock: socket.SocketType, sock_lock: RLock
-) -> None:
+) -> bool:
     """Poll the hardware and send updates to the worker thread's queue.
 
     Args:
@@ -50,6 +79,9 @@ def poll_hardware(
         queue: the worker thread queue to add updates to after polling hardware
         sock: the socket instance
         sock_lock: the lock to use when using the socket instance
+
+    Returns:
+        True if the hardware poll was successful, False otherwise
 
     """
     try:
@@ -84,6 +116,8 @@ def poll_hardware(
                 )
             )
         )
+        return True
 
     except Exception:
         logger.exception("Error occurred when polling hardware: ")
+        return False

--- a/tests/threads/test_hardware_polling_thread.py
+++ b/tests/threads/test_hardware_polling_thread.py
@@ -1,3 +1,4 @@
+import logging
 from queue import Queue
 from threading import RLock
 from unittest.mock import MagicMock, Mock, call, patch
@@ -10,7 +11,7 @@ from kafka_dae_control.defaults import (
     RunRegister,
 )
 from kafka_dae_control.threads.hardware_polling_thread import hardware_poll_thread
-from kafka_dae_control.worker_event_types import HardwareUpdate
+from kafka_dae_control.worker_event_types import HardwareUpdate, SetIPEvent
 
 
 @patch("kafka_dae_control.threads.hardware_polling_thread.sleep", side_effect=Exception)
@@ -82,3 +83,30 @@ def test_read_throws_exception_logs(
         hardware_poll_thread(conf, queue, sock, sock_lock)
 
     assert "Error occurred when polling hardware: " in caplog.text
+
+
+@patch(
+    "kafka_dae_control.threads.hardware_polling_thread.sleep",
+    side_effect=[None, None, None, Exception],
+)
+@patch("kafka_dae_control.threads.hardware_polling_thread.poll_hardware", return_value=False)
+def test_many_comms_errors_in_a_row_cause_ip_to_be_resent(
+    mock_read: Mock, mock_sleep: Mock, conf: ControlConfig, caplog: pytest.LogCaptureFixture
+):
+    conf.resend_ip_after_connection_failures = 3
+
+    queue = Queue()
+    sock = MagicMock()
+    sock_lock = MagicMock(spec=RLock())
+
+    caplog.set_level(logging.DEBUG)
+
+    with pytest.raises(Exception):  # ruff:ignore[assert-raises-exception, pytest-raises-too-broad]
+        hardware_poll_thread(conf, queue, sock, sock_lock)
+
+    assert "1 comms errors in a row while polling hardware" in caplog.text
+    assert "2 comms errors in a row while polling hardware" in caplog.text
+    assert "3 comms errors in a row while polling hardware" in caplog.text
+    assert "Attempting to resend local IP to streaming control board to recover" in caplog.text
+
+    assert isinstance(queue.get(), SetIPEvent)


### PR DESCRIPTION
If the streaming control board fails to read data during a `poll_hardware` several times in a row, a `SetIPEvent()` is put onto the queue for the worker thread to pick up.

Closes https://github.com/ISISComputingGroup/DataStreaming/issues/48